### PR TITLE
removes + before data parameter to look up recipient by phone

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -344,7 +344,7 @@ class Client extends Guzzle
     public function getRecipientByPhone($phone)
     {
         $phone    = preg_replace('/[^\d]/', '', $phone);
-        $response = $this->get('recipients/phone/+'.$phone);
+        $response = $this->get('recipients/phone/'.$phone);
 
         if (null === $response) {
             return null;


### PR DESCRIPTION
I noticed that the getRecipientByPhone() function was never returning data. I investigated and found OnFleet does not require the '+' symbol before phone numbers for this method.